### PR TITLE
Fix rexster-kibbles/pom.xml

### DIFF
--- a/rexster-kibbles/pom.xml
+++ b/rexster-kibbles/pom.xml
@@ -9,6 +9,7 @@
         <version>0.8-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
+    <groupId>com.tinkerpop.rexster-kibbles</groupId>
     <artifactId>rexster-kibbles</artifactId>
     <version>0.8-SNAPSHOT</version>
     <packaging>pom</packaging>


### PR DESCRIPTION
The rexster-kibbles submodules expected their parent to have the groupId
com.tinkerpop.rexster-kibbles, but the parent pom.xml didn't explicitly
set its groupId to that, causing it to inherit its groupId from the main
rexster pom.xml, setting it incorrectly to com.tinkerpop.rexster.
