### PR TITLE
Need to add sonatype nexus to repositories so Maven will see the orientdb snapshot.

### DIFF
--- a/rexster-server/pom.xml
+++ b/rexster-server/pom.xml
@@ -201,6 +201,11 @@
             <url>http://download.java.net/maven/glassfish/</url>
             <layout>default</layout>
         </repository>
+        <repository>
+            <id>sonatype-nexus-releases</id>
+            <name>Sonatype Nexus Releases</name>
+            <url>https://oss.sonatype.org/content/repositories/releases</url>
+        </repository>
     </repositories>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Otherwise, since Rexster depends on Blueprints, Maven will fail to resolve the transitive orientdb snapshot dependency.

This is the analogous change to https://github.com/tinkerpop/blueprints/commit/a6caa037b68406dd780ace8b45c8ed2b24c36b42
