### PR TITLE
fixing msgpack script response result array serialization

### DIFF
--- a/rexster-protocol/src/test/java/com/tinkerpop/rexster/gremlin/converter/MsgPackResultConverterTest.java
+++ b/rexster-protocol/src/test/java/com/tinkerpop/rexster/gremlin/converter/MsgPackResultConverterTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import static org.msgpack.template.Templates.tMap;
 import static org.msgpack.template.Templates.TString;
 import static org.msgpack.template.Templates.TValue;
+import static org.msgpack.template.Templates.tList;
 
 
 public class MsgPackResultConverterTest {
@@ -76,7 +77,12 @@ public class MsgPackResultConverterTest {
         byte[] converted = this.converter.convert(g.getVertices());
 
         final BufferUnpacker unpacker = msgpack.createBufferUnpacker(converted);
-        final UnpackerIterator unpackerItty = unpacker.iterator();
+        final Object unpacked = unpacker.readValue();
+
+        Assert.assertTrue(unpacked instanceof Iterable);
+
+        final Iterator unpackerItty = ((Iterable) unpacked).iterator();
+
         int counter = 0;
         while (unpackerItty.hasNext()) {
             unpackerItty.next();
@@ -99,14 +105,18 @@ public class MsgPackResultConverterTest {
         Assert.assertNotNull(converted);
 
         final BufferUnpacker unpacker = msgpack.createBufferUnpacker(converted);
-        final UnpackerIterator unpackerItty = unpacker.iterator();
+        final Object unpacked = unpacker.readValue();
+
+        Assert.assertTrue(unpacked instanceof Iterable);
+
+        final Iterator unpackerItty = ((Iterable) unpacked).iterator();
 
         int counter = 0;
         boolean matchX = false;
         boolean matchY = false;
 
         while (unpackerItty.hasNext()) {
-            final Value v = unpackerItty.next();
+            final Value v = (Value) unpackerItty.next();
             if (v.asRawValue().getString().equals("x")) {
                 matchX = true;
             }
@@ -133,14 +143,18 @@ public class MsgPackResultConverterTest {
         byte[] converted = this.converter.convert(iterable);
 
         final BufferUnpacker unpacker = msgpack.createBufferUnpacker(converted);
-        final UnpackerIterator unpackerItty = unpacker.iterator();
+        final Object unpacked = unpacker.readValue();
+
+        Assert.assertTrue(unpacked instanceof Iterable);
+
+        final Iterator unpackerItty = ((Iterable) unpacked).iterator();
 
         int counter = 0;
         boolean matchX = false;
         boolean matchY = false;
 
         while (unpackerItty.hasNext()) {
-            final Value v = unpackerItty.next();
+            final Value v = (Value) unpackerItty.next();
             if (v.asRawValue().getString().equals("x")) {
                 matchX = true;
             }
@@ -168,7 +182,8 @@ public class MsgPackResultConverterTest {
         byte[] converted = this.converter.convert(iterable);
 
         final BufferUnpacker unpacker = msgpack.createBufferUnpacker(converted);
-        final UnpackerIterator unpackerItty = unpacker.iterator();
+        final Object unpacked = unpacker.readValue();
+        final Iterator unpackerItty = ((Iterable) unpacked).iterator();
 
         int counter = 0;
         boolean matchX = false;
@@ -176,7 +191,7 @@ public class MsgPackResultConverterTest {
         boolean matchNil = false;
 
         while (unpackerItty.hasNext()) {
-            final Value v = unpackerItty.next();
+            final Value v = (Value) unpackerItty.next();
             if (v.isRawValue() && v.asRawValue().getString().equals("x")) {
                 matchX = true;
             }

--- a/rexster-protocol/src/test/java/com/tinkerpop/rexster/protocol/msg/MsgPackScriptResponseMessageTest.java
+++ b/rexster-protocol/src/test/java/com/tinkerpop/rexster/protocol/msg/MsgPackScriptResponseMessageTest.java
@@ -1,7 +1,14 @@
 package com.tinkerpop.rexster.protocol.msg;
 
+import com.tinkerpop.rexster.protocol.BitWorks;
 import junit.framework.Assert;
 import org.junit.Test;
+import org.msgpack.MessagePack;
+import org.msgpack.unpacker.Unpacker;
+
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
@@ -15,4 +22,76 @@ public class MsgPackScriptResponseMessageTest {
 
         Assert.assertEquals(56, msg.estimateMessageSize());
     }
+
+    final static MessagePack msgpack = new MessagePack();
+
+    @Test
+    public void serializeString() throws Exception {
+        byte[] bytes = MsgPackScriptResponseMessage.convertResultToBytes("xyz");
+        Unpacker unpacker = msgpack.createUnpacker(new ByteArrayInputStream(bytes));
+        Object dst = BitWorks.deserializeObject(unpacker.readValue());
+
+        Assert.assertEquals("xyz", dst);
+    }
+
+    @Test
+    public void serializeInt() throws Exception {
+        byte[] bytes = MsgPackScriptResponseMessage.convertResultToBytes(31);
+        Unpacker unpacker = msgpack.createUnpacker(new ByteArrayInputStream(bytes));
+        Object dst = BitWorks.deserializeObject(unpacker.readValue());
+
+        Assert.assertEquals(31, dst);
+    }
+
+    @Test
+    public void serializeFloat() throws Exception {
+        byte[] bytes = MsgPackScriptResponseMessage.convertResultToBytes(1.2);
+        Unpacker unpacker = msgpack.createUnpacker(new ByteArrayInputStream(bytes));
+        Object dst = BitWorks.deserializeObject(unpacker.readValue());
+
+        Assert.assertEquals(1.2, dst);
+    }
+
+    @Test
+    public void serializeBool() throws Exception {
+        byte[] bytes = MsgPackScriptResponseMessage.convertResultToBytes(true);
+        Unpacker unpacker = msgpack.createUnpacker(new ByteArrayInputStream(bytes));
+        Object dst = BitWorks.deserializeObject(unpacker.readValue());
+
+        Assert.assertEquals(true, dst);
+    }
+
+    @Test
+    public void serializeArray() throws Exception {
+        ArrayList<Object> srcArray = new ArrayList<Object>();
+        srcArray.add(true);
+        srcArray.add("abc");
+        srcArray.add(1);
+
+        byte[] bytes = MsgPackScriptResponseMessage.convertResultToBytes(srcArray);
+        Unpacker unpacker = msgpack.createUnpacker(new ByteArrayInputStream(bytes));
+        Object dst = BitWorks.deserializeObject(unpacker.readValue());
+
+        Assert.assertEquals(srcArray, dst);
+    }
+
+    @Test
+    public void serializeMap() throws Exception {
+        HashMap<Object, Object> srcMap = new HashMap<Object, Object>();
+        srcMap.put("city", "LA");
+        srcMap.put(1, 2);
+        ArrayList<Object> arr = new ArrayList<Object>();
+        arr.add(1);
+        arr.add("str");
+        arr.add(true);
+        srcMap.put(1.2d, arr);
+
+        byte[] bytes = MsgPackScriptResponseMessage.convertResultToBytes(srcMap);
+        Unpacker unpacker = msgpack.createUnpacker(new ByteArrayInputStream(bytes));
+        Object dst = BitWorks.deserializeObject(unpacker.readValue());
+        for (Object key : srcMap.keySet()) {
+            Assert.assertEquals(srcMap.get(key), ((HashMap<Object, Object>) dst).get(key));
+        }
+    }
+
 }


### PR DESCRIPTION
The initial method of serializing arrays did not call writeArrayStart and writeArrayEnd on the msgpack packer. While this worked fine if the top level object was an array, and you were deserializing with the java msgpack lib expecting the missing bytes, if an object contained in the results also included an array (ie a map value), or if you were doing msgpack deserialization in a different language (ie python) deserialization would break. Here, I've fixed that, updated the unit tests, and added some tests I used to debug the problem.

Please note that this patch will break existing rexpro applications relying on the current MsgPackScriptResponse message serialization behavior. However, the current behavior is incompatible with at least one msgpack implementation, and prevents the use of arrays anywhere except the top level result within java applications.
