### PR TITLE
Added method to close RexsterClient connections

### DIFF
--- a/rexster-protocol/src/main/java/com/tinkerpop/rexster/client/RexsterClient.java
+++ b/rexster-protocol/src/main/java/com/tinkerpop/rexster/client/RexsterClient.java
@@ -287,6 +287,14 @@ public class RexsterClient {
         RexsterClientFactory.removeClient(this);
     }
 
+    public void closeClientAndConnections() throws IOException {
+    	close();
+    	
+        for ( NIOConnection c : this.connections ) {
+            c.closeSilently();
+        }
+    } 
+
     private ScriptRequestMessage createNoSessionScriptRequest(final String script,
                                                               final Map<String, Object> scriptArguments) throws IOException, RexProException {
         final ScriptRequestMessage scriptMessage = new ScriptRequestMessage();


### PR DESCRIPTION
See discussion in inthefabric/RexConnect#7 for details, starting with [this comment](https://github.com/inthefabric/RexConnect/issues/7#issuecomment-17236514). Some highlights:

@zachkinstner:

> RexConnect currently creates a brand new RexsterClient for every single query command. [...] This adds between 0.5ms and 1.5ms to the total unit time [...] I've run tens of thousands of queries so far, and my file descriptor count is holding steady.

@spmallette:

> Interesting numbers. @bdeggleston you might be interested to take a look. The cost of creating new RexsterClient instances is pretty cheap. There is not much gained in re-using which is contrary to what i believed when i started writing it. I think your numbers seem to confirm that. Again, the semantics of RexsterClient may need to change given the powers Grizzly is providing that keeps that from being expensive. I've found that the expensive bits are in starting/stopping of the TCPNIOTransport

@zachkinstner:

> RexsterClient opens a connection using TCPNIOTransport.connect. Stephen, is your concern that the connections are being shared internally within the TCPNIOTransport? The docs imply that a connection is actually created/initialized, rather than being pulled from a pool
