### PR TITLE
Remove incompatibility with log4j-over-sl4j.

### DIFF
--- a/rexster-server/src/main/java/com/tinkerpop/rexster/server/HttpRexsterServer.java
+++ b/rexster-server/src/main/java/com/tinkerpop/rexster/server/HttpRexsterServer.java
@@ -390,10 +390,6 @@ public class HttpRexsterServer implements RexsterServer {
                 }
             }
 
-            if (LogManager.getLoggerRepository().getThreshold().isGreaterOrEqual(Level.TRACE)) {
-
-            }
-
             final ServletRegistration sg = wacJersey.addServlet("jersey", new ServletContainer(rc));
             sg.addMapping("/*");
             wacJersey.deploy(this.httpServer);


### PR DESCRIPTION
There's a bit of dead code in HttpRexsterServer that incidentally is
also incompatible with log4j-over-slf4j, an slf4j plugin that provides
alternate implementations of log4j classes that send logging messages to
slf4j instead.
