### PR TITLE
fix NPE in RexsterClient when using MsgPackSerializer with null result (fixes issue #327)

### DIFF
--- a/rexster-protocol/src/main/java/com/tinkerpop/rexster/protocol/serializer/msgpack/templates/messages/MsgPackScriptResponseMessageTemplate.java
+++ b/rexster-protocol/src/main/java/com/tinkerpop/rexster/protocol/serializer/msgpack/templates/messages/MsgPackScriptResponseMessageTemplate.java
@@ -1,5 +1,6 @@
 package com.tinkerpop.rexster.protocol.serializer.msgpack.templates.messages;
 
+import com.tinkerpop.rexster.protocol.msg.RexProScriptResult;
 import com.tinkerpop.rexster.protocol.msg.ScriptResponseMessage;
 import com.tinkerpop.rexster.protocol.serializer.msgpack.templates.BindingsTemplate;
 import com.tinkerpop.rexster.protocol.serializer.msgpack.templates.ResultsTemplate;
@@ -25,8 +26,8 @@ public class MsgPackScriptResponseMessageTemplate extends RexProMessageTemplate<
     @Override
     protected ScriptResponseMessage readMessageArray(final Unpacker un, final ScriptResponseMessage msg) throws IOException {
         ScriptResponseMessage message = super.readMessageArray(un, msg);
-
-        message.Results = ResultsTemplate.getInstance().read(un, null);
+        RexProScriptResult scriptResult = ResultsTemplate.getInstance().read(un, null);
+        message.Results.set(scriptResult == null ? null : scriptResult.get());
         message.Bindings = BindingsTemplate.getInstance().read(un, null);
         return message;
     }

--- a/rexster-server/src/integration/java/com/tinkerpop/rexster/rexpro/AbstractRexsterClientIntegrationTest.java
+++ b/rexster-server/src/integration/java/com/tinkerpop/rexster/rexpro/AbstractRexsterClientIntegrationTest.java
@@ -36,6 +36,11 @@ public abstract class AbstractRexsterClientIntegrationTest extends AbstractRexPr
     public void executeExercise() throws Exception {
         final RexsterClient client = getClient();
 
+        final List<Object> nullResults = client.execute("null");
+        Assert.assertEquals(1, nullResults.size());
+        final Object nullResult = nullResults.get(0);
+        Assert.assertEquals(null, nullResult);
+
         final List<Map<String, Object>> mapResults = client.execute("[val:1+1]");
         Assert.assertEquals(1, mapResults.size());
         final Map<String, Object> mapResult = mapResults.get(0);


### PR DESCRIPTION
Hello, 

We've experienced same NPE outlined in #327 when using default serializer with RexsterClient. 
This change makes null response similar to JsonSerializer's response. 
Test is provided.
