### PR TITLE
Fix config error for MetricsServlet

### DIFF
--- a/rexster-server/src/main/java/com/tinkerpop/rexster/server/HttpRexsterServer.java
+++ b/rexster-server/src/main/java/com/tinkerpop/rexster/server/HttpRexsterServer.java
@@ -466,8 +466,8 @@ public class HttpRexsterServer implements RexsterServer {
                 // deploys the metrics servlet into rexster
                 wacMetrics = new WebappContext("metrics", "");
                 wacMetrics.setAttribute("com.codahale.metrics.servlets.MetricsServlet.registry", application.getMetricRegistry());
-                wacMetrics.setAttribute("com.codahale.metrics.servlets.MetricsServlet.rateUnit", this.convertRateTo);
-                wacMetrics.setAttribute("com.codahale.metrics.servlets.MetricsServlet.durationUnit", this.convertDurationTo);
+                wacMetrics.setInitParameter("com.codahale.metrics.servlets.MetricsServlet.rateUnit", this.convertRateTo);
+                wacMetrics.setInitParameter("com.codahale.metrics.servlets.MetricsServlet.durationUnit", this.convertDurationTo);
 
                 final ServletRegistration sgMetrics = wacMetrics.addServlet("metrics", new MetricsServlet());
                 sgMetrics.addMapping("/metrics/*");


### PR DESCRIPTION
Should use setInitParameter() instead of setAttribute() to configure com.codahale.metrics.servlets.MetricsServlet. Otherwise, the rate unit and the duration unit will not be set as written in the XML configure file.
