### PR TITLE
bin/ scripts to follow symlinks

### DIFF
--- a/rexster-console/src/main/bin/rexster-console.sh
+++ b/rexster-console/src/main/bin/rexster-console.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 
-CP=$( echo `dirname $0`/../lib/*.jar . | sed 's/ /:/g')
-CP=$CP:$( echo `dirname $0`/../ext/*.jar . | sed 's/ /:/g')
+# From: http://stackoverflow.com/a/246128
+#   - To resolve finding the directory after symlinks
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+CP=$( echo $DIR/../lib/*.jar . | sed 's/ /:/g')
+CP=$CP:$( echo $DIR/../ext/*.jar . | sed 's/ /:/g')
 #echo $CP
 
 # Find Java

--- a/rexster-server/src/main/bin/rexster.sh
+++ b/rexster-server/src/main/bin/rexster.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
 
-CP=$( echo `dirname $0`/../lib/*.jar . | sed 's/ /:/g')
-CP=$CP:$(find -L `dirname $0`/../ext/ -name "*.jar" | tr '\n' ':')
+# From: http://stackoverflow.com/a/246128
+#   - To resolve finding the directory after symlinks
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+CP=$( echo $DIR/../lib/*.jar . | sed 's/ /:/g')
+CP=$CP:$(find -L $DIR/../ext/ -name "*.jar" | tr '\n' ':')
 
 REXSTER_EXT=../ext
 
-PUBLIC=`dirname $0`/../public/
+PUBLIC=$DIR/../public/
 EXTRA=
 
 if [ $1 = "-s" ] ; then


### PR DESCRIPTION
Since many applications now symlink one, or more, times, into multiple directories these
scripts needed updated to accurately follow said symlinks. Previously, if symlinks were
present, the script would fail to find all of the .jar files in the library because it
would only find the immediate path it was installed in. For example, if we symlinked
rexster.sh to /usr/local/bin/rexster and attempted to call it, the script would only
look in /usr/local/lib/ for its jar files.
