### PR TITLE
Wait for rexster service to stop

### DIFF
--- a/rexster-server/src/main/bin/rexster-service.sh
+++ b/rexster-server/src/main/bin/rexster-service.sh
@@ -54,6 +54,10 @@ stop() {
     fi
     echo "Stopping Rexster server..."
     su -c "cd \"$REXSTER_DIR\"; /usr/bin/nohup ./bin/rexster.sh -x 1>$REXSTER_LOG_DIR/service-stop.log 2>$REXSTER_LOG_DIR/service-stop.err &" $REXSTER_USER
+    while kill -0 $PID 2> /dev/null; do
+        echo "Waiting for $PID..." 
+        sleep 1
+    done
 }
 
 status() {


### PR DESCRIPTION
Rexster service sometimes takes a while to shut down. Make sure service is stopped before starting it again, in case we're using an utility like monit to restart the service
