### PR TITLE
Allow to set request timeout

### DIFF
--- a/rexster-protocol/src/main/java/com/tinkerpop/rexster/client/RemoteRexsterSession.java
+++ b/rexster-protocol/src/main/java/com/tinkerpop/rexster/client/RemoteRexsterSession.java
@@ -107,10 +107,14 @@ public class RemoteRexsterSession {
     }
 
     public RexProMessage sendRequest(RexProMessage request, int maxRetries) {
-        return sendRequest(request, maxRetries, 3000);
+        return sendRequest(request, maxRetries, 3000, this.timeout);
     }
 
     public RexProMessage sendRequest(RexProMessage request, int maxRetries, int waitMsBetweenTries) {
+        return sendRequest(request, maxRetries, waitMsBetweenTries, this.timeout);
+    }
+
+    public RexProMessage sendRequest(RexProMessage request, int maxRetries, int waitMsBetweenTries, int timeoutSeconds) {
         int tries = 0;
         RexProMessage rcvMessage = null;
 
@@ -121,7 +125,7 @@ public class RemoteRexsterSession {
             tries++;
 
             try {
-                rcvMessage = rexProConnection.sendMessage(request);
+                rcvMessage = rexProConnection.sendMessage(request, timeoutSeconds);
             } catch (Exception ex) {
                 String logMessage = "Failure sending message via RexPro. Attempt [" + tries + "] of [" + maxRetries + "].";
 


### PR DESCRIPTION
This should fix issue #365 ; I run the tests and it seems to work as expected, please review and let me know if you see anything strange (also, I tested it against the `2.7-SNAPSHOT`, but this should probably be merged into `2.5` or `2.6` as well)

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] Rexster ........................................... SUCCESS [0.872s]
[INFO] Rexster: Core Components .......................... SUCCESS [19.389s]
[INFO] Rexster: RexPro Binary Protocol ................... SUCCESS [11.689s]
[INFO] Rexster: A Graph Server ........................... SUCCESS [4:53.948s]
[INFO] Rexster Kibbles: Frames ........................... SUCCESS [15.187s]
[INFO] Rexster Kibbles: General-Purpose Rexster Extensions  SUCCESS [0.140s]
[INFO] Rexster Kibbles: Sample ........................... SUCCESS [1.552s]
[INFO] Rexster Kibbles: SPARQL ........................... SUCCESS [26.058s]
[INFO] Rexster Kibbles: Batch ............................ SUCCESS [1.122s]
[INFO] Rexster Console: A Remote REPL for Rexster ........ SUCCESS [0.488s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 6:10.790s
[INFO] Finished at: Tue Nov 11 16:04:59 CET 2014
[INFO] Final Memory: 36M/151M
[INFO] ------------------------------------------------------------------------
```
