### PR TITLE
Close transport when closing a RexPro connection

### DIFF
--- a/rexster-protocol/src/main/java/com/tinkerpop/rexster/client/RexProClientConnection.java
+++ b/rexster-protocol/src/main/java/com/tinkerpop/rexster/client/RexProClientConnection.java
@@ -25,10 +25,9 @@ public final class RexProClientConnection {
 
     private final Connection connection;
     private final BlockingQueue<RexProMessage> responseQueue = new SynchronousQueue<RexProMessage>(true);
+    private final TCPNIOTransport transport = getTransport(responseQueue);
 
     public RexProClientConnection(String rexProHost, int rexProPort) {
-        TCPNIOTransport transport = getTransport(responseQueue);
-
         try {
             transport.start();
 
@@ -54,6 +53,11 @@ public final class RexProClientConnection {
 
     public void close() {
         connection.close();
+        try {
+            transport.stop();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
     public static TCPNIOTransport getTransport(final BlockingQueue<RexProMessage> responseQueue) {


### PR DESCRIPTION
Not closing the transport lead to some leftovers, which caused a `java.io.IOException: Too many open files` on the long run (possibly the cause of https://github.com/tinkerpop/rexster/wiki/Troubleshooting#too-many-open-files-when-running-integration-tests as well).
