### PR TITLE
Fix Travis breaking due to possible dependency conflict.

### DIFF
--- a/rexster-kibbles/frames-kibble/pom.xml
+++ b/rexster-kibbles/frames-kibble/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.tinkerpop.rexster</groupId>
         <artifactId>rexster-kibbles</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>com.tinkerpop.rexster.rexster-kibbles</groupId>
@@ -22,7 +22,13 @@
         <dependency>
             <groupId>com.tinkerpop</groupId>
             <artifactId>frames</artifactId>
-            <version>${tinkerpop.version}</version>
+            <version>2.6.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.tinkerpop.blueprints</groupId>
+                    <artifactId>blueprints-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- CONFIGURATION -->
         <dependency>


### PR DESCRIPTION
Supplies a temporary solution to current Travis builds breaking for Rexster.  Possibly caused by dependency conflict between blueprints-core 2.6 and blueprints core 2.7.0-SNAPSHOT.   

I'm guessing the version was left at 2.6 because the dependency for  frames 2.7.0-SNAPSHOT is apparently missing:

```
[ERROR] Failed to execute goal on project frames-kibble: Could not resolve dependencies for project 
 com.tinkerpop.rexster.rexster-kibbles:frames-kibble:jar:2.7.0-SNAPSHOT: Could not find artifact
 com.tinkerpop:frames:jar:2.7.0-SNAPSHOT in sonatype-snapshots.
```
