### PR TITLE
Solution for issues #372 and #350

### DIFF
--- a/rexster-server/config/rexster.xml
+++ b/rexster-server/config/rexster.xml
@@ -3,7 +3,7 @@
     <http>
         <server-port>8182</server-port>
         <server-host>0.0.0.0</server-host>
-        <base-uri>http://localhost</base-uri>
+        <base-uri>http://localhost:8182</base-uri>
         <web-root>public</web-root>
         <character-set>UTF-8</character-set>
         <enable-jmx>false</enable-jmx>

--- a/rexster-server/src/integration/resources/com/tinkerpop/rexster/rexster-integration-test.xml
+++ b/rexster-server/src/integration/resources/com/tinkerpop/rexster/rexster-integration-test.xml
@@ -3,7 +3,7 @@
     <http>
         <server-port>8182</server-port>
         <server-host>0.0.0.0</server-host>
-        <base-uri>http://localhost</base-uri>
+        <base-uri>http://localhost:8182</base-uri>
         <web-root>public</web-root>
         <character-set>UTF-8</character-set>
         <enable-jmx>false</enable-jmx>

--- a/rexster-server/src/main/java/com/tinkerpop/rexster/server/HttpRexsterServer.java
+++ b/rexster-server/src/main/java/com/tinkerpop/rexster/server/HttpRexsterServer.java
@@ -450,7 +450,7 @@ public class HttpRexsterServer implements RexsterServer {
                 this.wacDogHouse = new WebappContext("doghouse", "");
                 final ServletRegistration sgDogHouse = wacDogHouse.addServlet("doghouse", new DogHouseServlet());
                 sgDogHouse.addMapping("/doghouse/*");
-                sgDogHouse.setInitParameter("com.tinkerpop.rexster.config.rexsterApiBaseUri", baseUri + ":" + rexsterServerPort.toString());
+                sgDogHouse.setInitParameter("com.tinkerpop.rexster.config.rexsterApiBaseUri", baseUri);
 
                 final ServletRegistration sgDogHouseEval = wacDogHouse.addServlet("doghouse-evaluator", new EvaluatorServlet(application));
                 sgDogHouseEval.addMapping("/doghouse/exec");

--- a/rexster-server/src/performance/resources/com/tinkerpop/rexster/rexster-performance-test.xml
+++ b/rexster-server/src/performance/resources/com/tinkerpop/rexster/rexster-performance-test.xml
@@ -3,7 +3,7 @@
     <http>
         <server-port>8182</server-port>
         <server-host>0.0.0.0</server-host>
-        <base-uri>http://localhost</base-uri>
+        <base-uri>http://localhost:8182</base-uri>
         <web-root>public</web-root>
         <character-set>UTF-8</character-set>
         <enable-jmx>false</enable-jmx>

--- a/rexster-server/src/test/java/com/tinkerpop/rexster/server/RexsterXmlData.java
+++ b/rexster-server/src/test/java/com/tinkerpop/rexster/server/RexsterXmlData.java
@@ -14,7 +14,7 @@ public final class RexsterXmlData {
             "    <rexpro-server-host>0.0.0.0</rexpro-server-host>\n" +
             "    <rexpro-session-max-idle>1790000</rexpro-session-max-idle>\n" +
             "    <rexpro-session-check-interval>3000000</rexpro-session-check-interval>\n" +
-            "    <base-uri>http://localhost</base-uri>\n" +
+            "    <base-uri>http://localhost:8182</base-uri>\n" +
             "    <web-root>public</web-root>\n" +
             "    <character-set>UTF-8</character-set>\n" +
             "    <security>\n" +


### PR DESCRIPTION
## The problem
When Rexster ran behind a proxy server on a different port, the Doghouse AJAX-requests still tried to use the 'server-port' configured in 'rexster.xml'.

## Solution
I changed the code that adds the 'server-port' to the 'base-uri'. Now the 'base-uri' has to consist the port number the server runs on. This makes it more flexible.